### PR TITLE
Update version dependency for event-stream

### DIFF
--- a/lib/utils/package.json
+++ b/lib/utils/package.json
@@ -21,7 +21,7 @@
     "chai": "^2.3.0",
     "deamdify": "^0.1.1",
     "del": "^1.1.1",
-    "event-stream": "~>3.3.5",
+    "event-stream": "3.3.5",
     "gulp": "^3.8.11",
     "gulp-browserify": "^0.5.1",
     "gulp-bump": "^0.3.1",

--- a/lib/utils/package.json
+++ b/lib/utils/package.json
@@ -21,7 +21,7 @@
     "chai": "^2.3.0",
     "deamdify": "^0.1.1",
     "del": "^1.1.1",
-    "event-stream": "^3.3.1",
+    "event-stream": "~>3.3.5",
     "gulp": "^3.8.11",
     "gulp-browserify": "^0.5.1",
     "gulp-bump": "^0.3.1",


### PR DESCRIPTION
Addreses security alert for event-stream < 3.3.4 (flatmap-stream malicious library injection).